### PR TITLE
Update Dai Foundation CLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,84 @@
-# MAKERDAO-CLA
-This repository is to contain source versions of Contributor License Agreements to be used when assets are handed over to the Dai Foundation
+# MakerDAO Individual Contributor Assignment Agreement ("Agreement") 
+
+Thank you for your interest in MakerDAO ("MakerDAO"). In order to clarify the intellectual property rights granted for Contributions from any person or entity, the Dai Foundation (acting on behalf of MakerDAO and its authorised representatives) must have a Contributor Assignment Agreement on file that has been signed by each Contributor, indicating agreement to the assignment terms below. 
+
+In consideration for access to Dai Foundation's and MakerDAO's Intellectual Property Rights and the mutual promises made in this Agreement, the value of which is acknowledged as sufficient, You accept and agree to the following terms and conditions for Your present and future Contributions submitted to MakerDAO. 
+
+
+**1. Definitions.** "You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Dai Foundation acting on behalf of MakerDAO and its authorised representatives. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity. "Business Day" means any day except a Saturday, Sunday or public holiday in Copenhagen, Denmark. "Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to MakerDAO for inclusion in, or documentation of, any of the products owned or managed by MakerDAO (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to MakerDAO or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, MakerDAO for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution." "Intellectual Property Rights" means the rights comprised in any patent or patentable invention, copyright, design, trade mark, eligible layout or similar right whether at common law, civil law or conferred by statute, rights to apply for registration under a statute in respect of those or like rights and rights to protect trade secrets, know how or confidential information throughout the world for the full period of the rights, along with all renewals and extensions. 
+
+
+**2. Interpretative Provisions** In this Agreement, unless the context otherwise requires:
+(a) the background is correct;
+(b) headings do not affect interpretation;
+(c) the singular includes the plural and vice versa;
+(d) words of one gender include any gender;
+(e) reference to legislation includes any amendment to it, any legislation substituted for it, and any subordinate legislation made under it;
+(f) reference to a person includes a corporation, joint venture, association, government body, firm and any other entity;
+(g) reference to a Party includes that Party's personal representatives, successors and permitted assignees;
+(h) reference to a thing (including a right) includes a part of that thing;
+(i) reference to two or more persons means each of them individually and any two or more of them jointly;
+(j) if a Party comprises two or more persons:
+    (i) reference to a Party means each of the persons individually and any two or more of them jointly;
+    (ii) a promise by that Party binds each of them individually and all of them jointly;
+    (iii) a right given to that Party is given to each of them individually; and
+    (iv) a representation, warranty or undertaking by that Party is made by each of them individually;
+(k) a provision must not be construed against a Party only because that Party prepared it;
+(l) a provision must be read down to the extent necessary to be valid. If it cannot be read down to that extent, it must be severed;
+(m) if a thing is to be done on a day which is not a Business Day, it must be done on the Business Day before that day;
+(n) another grammatical form of a defined expression has a corresponding meaning.
+
+
+**3. Assignment** You agree to assign absolutely and encumbrance free to the Dai Foundation:
+(a) all right, title, interest and benefit throughout the world in all Intellectual Property Rights in respect of the Contributions; and
+(b) the right to take any action that the Dai Foundation has had or may have against any person to recover damages, accounts of profit or other relief for any infringement or misuse of any Intellectual Property Rights in respect of any of the Contributions including any such infringement or misuse prior to the date of this agreement, such assignment to take effect from the date of this Agreement.
+
+**4. Moral Rights Consent**
+You consent in favour of the Dai Foundation, its assignees, successors in title and any person authorised by the Dai Foundation or MakerDAO that they may carry out any activity, including any acts or omissions to act, in respect of the Contributions and Works, the performance or non-performance of which would otherwise infringe Your moral rights.
+
+
+**5. Warranties.** You warrant to the Dai Foundation that:
+(a) each of the Intellectual Property Rights and Contributions is original and was created by You and no other person;
+(b) You own all the Intellectual Property Rights and are able to assign to the Dai Foundation the rights referred to in clause 3, encumbrance free;
+(c) You are not aware of any act or information which would invalidate any of the Intellectual Property Rights;
+(d) the use by the Dai Foundation and MakerDAO (or any other permitted user or licensee) of the Intellectual Property Rights will not infringe any right (including, without limitation, any Intellectual Property Rights) of any third party;
+(e) You have the legal right and power to enter into this Agreement and to complete the transactions contemplated by this Agreement;
+(f) You have made full disclosure to the Dai Foundation of all information within your reasonable and actual knowledge which would be material to the Dai Foundation;
+(g) the information given to the Dai Foundation by You or on Your behalf with respect to the Intellectual Property Rights is true, complete and accurate in all respects and none of that information is misleading, whether by inclusion of misleading information or omission of material information or both;
+(h) the Dai Foundation will be able to use for the purpose for which they were intended, each of the Intellectual Property Rights;
+(i) any material incorporated into any of the Technology:
+    (A) does not infringe the rights (including, without limitation, any Intellectual Property Rights), of any person;
+    (B) is not obscene, offensive, upsetting, defamatory, personally offensive or in any way unsuitable for a person under the age of 18 years; and
+    (C) does not comprise, and cannot be used, for any purpose or activity of an illegal, fraudulent or defamatory nature.
+
+
+**6. Authorization.** You represent that you are legally entitled to enter into this Agreement. If your employer(s) has Intellectual Property Rights that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to the Dai Foundation, or that your employer has executed a separate Corporate CLA with Dai Foundation. 
+
+
+**7. No Support Obligation.** You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON- INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. 
+
+
+**8. Licensed Works.** Should You wish to submit work that is not Your original creation, You may submit it to Dai Foundation separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]". 
+
+
+**9. Governing Law.** This Agreement is governed by the laws of Denmark. You irrevocably submit to the exclusive jurisdiction of the Copenhagen City Court, Denmark and the courts of appeal from it.
+ 
+
+
+Please sign: 
+
+Name:
+
+Signature: __________________________________ Date: ________________
+
+
+Signed by the following authorised representative on behalf of the Dai Foundation:
+
+Name:
+
+Signature: __________________________________ Date: ________________
+
+
+
+
+Prepared by Paul Imseih (Daimon Legal) on behalf of the Dai Foundation - © Dai Foundation 2023


### PR DESCRIPTION
This form of CLA ensures that MakerDAO intangible assets are appropriately maintained in the Dai Foundation's repository and can be licensed to other contributors and the broader developer community in line with the open-source and public good principles established by the MakerDAO Alignment Artefacts.